### PR TITLE
Collation gas limit

### DIFF
--- a/sharding/config.py
+++ b/sharding/config.py
@@ -37,6 +37,7 @@ sharding_config['CONTRACT_CALL_GAS'] = {
         'get_receipts__data': 40000,
         'get_receipts__tx_startgas': 40000,
         'get_receipts__tx_gasprice': 40000,
+        'get_collation_gas_limit': 40000,
     }),
     'USED_RECEIPT_STORE': defaultdict(lambda: 200000, {
         'get_used_receipts': 40000,

--- a/sharding/tests/test_collator.py
+++ b/sharding/tests/test_collator.py
@@ -107,7 +107,7 @@ def test_apply_collation():
     collation = t.generate_collation(shard_id=1, coinbase=tester.a1, key=tester.k1, txqueue=txqueue)
     period_start_prevblock = t.chain.get_block(collation.header.period_start_prevhash)
 
-    collator.apply_collation(state, collation, period_start_prevblock)
+    collator.apply_collation(state, collation, period_start_prevblock, t.chain.state)
 
     assert state.trie.root_hash != prev_state_root
     assert collation.header.post_state_root == state.trie.root_hash
@@ -132,7 +132,7 @@ def test_apply_collation_wrong_root():
     # Set wrong root
     collation.header.post_state_root = trie.BLANK_ROOT
     with pytest.raises(ValueError):
-        collator.apply_collation(state, collation, period_start_prevblock)
+        collator.apply_collation(state, collation, period_start_prevblock, t.chain.state)
 
     # test 2 - arrange
     state = t.chain.shards[shard_id].state
@@ -145,7 +145,7 @@ def test_apply_collation_wrong_root():
     # Set wrong root
     collation.header.receipts_root = trie.BLANK_ROOT
     with pytest.raises(ValueError):
-        collator.apply_collation(state, collation, period_start_prevblock)
+        collator.apply_collation(state, collation, period_start_prevblock, t.chain.state)
 
     # test 3 - arrange
     state = t.chain.shards[shard_id].state
@@ -158,7 +158,7 @@ def test_apply_collation_wrong_root():
     # Set wrong root
     collation.header.tx_list_root = trie.BLANK_ROOT
     with pytest.raises(ValueError):
-        collator.apply_collation(state, collation, period_start_prevblock)
+        collator.apply_collation(state, collation, period_start_prevblock, t.chain.state)
 
 
 def test_verify_collation_header():

--- a/sharding/tests/test_shard_chain.py
+++ b/sharding/tests/test_shard_chain.py
@@ -36,9 +36,7 @@ def test_add_collation():
     """Test add_collation(self, collation, period_start_prevblock)
     """
     shard_id = 1
-    t = tester.Chain(env='sharding')
-    t.chain.init_shard(shard_id)
-    t.mine(5)
+    t = chain(shard_id)
 
     # parent = empty
     collation1 = t.generate_collation(shard_id=1, coinbase=tester.a1, key=tester.k1, txqueue=None)
@@ -66,9 +64,7 @@ def test_add_collation_error():
     """Test add_collation(self, collation, period_start_prevblock)
     """
     shard_id = 1
-    t = tester.Chain(env='sharding')
-    t.chain.init_shard(shard_id)
-    t.mine(5)
+    t = chain(shard_id)
 
     # parent = empty
     collation1 = t.generate_collation(shard_id=1, coinbase=tester.a1, key=tester.k1, txqueue=None)
@@ -89,10 +85,8 @@ def test_handle_ignored_collation():
     """Test handle_ignored_collation(self, collation, period_start_prevblock)
     """
     shard_id = 1
-    # Collator: create and apply collation sequentially
-    t1 = tester.Chain(env='sharding')
-    t1.chain.init_shard(shard_id)
-    t1.mine(5)
+    t1 = chain(shard_id)
+
     # collation1
     collation1 = t1.generate_collation(shard_id=1, coinbase=tester.a1, key=tester.k1, txqueue=None)
     period_start_prevblock = t1.chain.get_block(collation1.header.period_start_prevhash)
@@ -110,9 +104,7 @@ def test_handle_ignored_collation():
     assert t1.chain.shards[shard_id].get_score(collation3) == 3
 
     # Validator: apply collation2, collation3 and collation1
-    t2 = tester.Chain(env='sharding')
-    t2.chain.init_shard(shard_id)
-    t2.mine(5)
+    t2 = chain(shard_id)
     # append collation2
     t2.chain.shards[shard_id].add_collation(collation2, period_start_prevblock)
     # append collation3
@@ -162,10 +154,7 @@ def test_get_collation():
     """Test get_parent(self, collation)
     """
     shard_id = 1
-    t = tester.Chain(env='sharding')
-
-    t.chain.init_shard(shard_id)
-    t.mine(5)
+    t = chain(shard_id)
 
     collation = t.generate_collation(shard_id=1, coinbase=tester.a1, key=tester.k1, txqueue=None)
     period_start_prevblock = t.chain.get_block(collation.header.period_start_prevhash)
@@ -177,10 +166,8 @@ def test_get_collation():
 def test_get_parent():
     """Test get_parent(self, collation)
     """
-    t = tester.Chain(env='sharding')
     shard_id = 1
-    t.chain.init_shard(shard_id)
-    t.mine(5)
+    t = chain(shard_id)
 
     collation = t.generate_collation(shard_id=1, coinbase=tester.a1, key=tester.k1, txqueue=None)
     period_start_prevblock = t.chain.get_block(collation.header.period_start_prevhash)
@@ -231,8 +218,8 @@ def test_sync():
 
 def test_cb_function():
     shard_id = 1
-    t = tester.Chain(env='sharding')
-    shard = ShardChain(shard_id=shard_id, new_head_cb=cb_function, env=t.chain.env)
+    t = tester.Chain(env='sharding', deploy_sharding_contracts=True)
+    shard = ShardChain(shard_id=shard_id, new_head_cb=cb_function, env=t.chain.env, main_chain=t.chain)
 
     assert t.chain.add_shard(shard)
     t.mine(5)

--- a/sharding/tests/test_validator_manager_utils.py
+++ b/sharding/tests/test_validator_manager_utils.py
@@ -201,3 +201,8 @@ def test_get_validators_max_index(chain):
         value=0, startgas=10 ** 20, sender_addr=t.a0
     )
     assert validators_max_index == 2
+
+
+def test_call_get_collation_gas_limit(chain):
+    output = call_valmgr(chain.head_state, 'get_collation_gas_limit', [])
+    assert output == 10000000

--- a/sharding/tools/tester.py
+++ b/sharding/tools/tester.py
@@ -394,7 +394,7 @@ class Chain(object):
             (10 ** 9) * utils.denoms.ether
         )
         initial_state.commit()
-        shard = ShardChain(shard_id=shard_id, initial_state=initial_state)
+        shard = ShardChain(shard_id=shard_id, initial_state=initial_state, main_chain=self.chain)
         self.chain.add_shard(shard)
         self.__init_shard_var(shard_id)
         if setup_urs_contracts:
@@ -577,5 +577,9 @@ def get_shard_head_state(
     assert period_start_prevblock is not None
     assert period_start_prevblock.number == expected_period_number * test_chain.chain.config['PERIOD_LENGTH'] - 1
     test_chain.cs.initialize(shard_head_state, period_start_prevblock)
+
+    # Collation Gas Limit
+    gas_limit = call_valmgr(test_chain.chain.state, 'get_collation_gas_limit', [])
+    shard_state_transition.set_collation_gas_limit(shard_head_state, gas_limit)
 
     return shard_head_state


### PR DESCRIPTION
## Description
1. Use the `collation_gas_limit` from validator manager contract as the gas limit for collations.
2. When the collators create the collation, check the collation gas limit.
3. When the validators verify the collation,  check the collation gas limit.
4. Set shard state `state.gas_limit` to the `collation_gas_limit` after initialize the state from block.
5. A lots of tests were been modified because in this case, all the `ShardChain` need to have the class member `ShardChain.main_chain` and the validator manger contract has already been deployed on these `MainChain`.

## How to test
```
pytest sharding/tests/test_state_transition.py::test_collation_gas_limit
```

## Cute Animal Picture
![polar_bears](https://media.giphy.com/media/kZF0QCIoN8fcc/giphy.gif)