### PR TITLE
docs: Sharding Spec clarity. macOS and Docker Setup. Troubleshooting steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:trusty
+RUN apt-get update
+# Install dependencies for PPA
+RUN apt-get install -y software-properties-common python-software-properties
+RUN add-apt-repository ppa:ethereum/ethereum
+RUN apt-get install -y tmux python-setuptools
+# C compilers required for cmake `build-essential`
+RUN apt-get install -y build-essential automake pkg-config libtool libffi-dev libgmp-dev python3-cffi
+RUN apt-get install -y python-dev libssl-dev python3-pip
+RUN apt-get install -y systemd libpam-systemd
+RUN apt-get install -y git wget unzip vim curl openssl
+
+# Download Python, extract, configure, compile, test, and install the build
+# Reference - https://passingcuriosity.com/2015/installing-python-from-source/
+ARG PYTHON_VERSION=3.6.4
+RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+# Ignore `make test`
+RUN tar xf Python-${PYTHON_VERSION}.tgz && cd Python-${PYTHON_VERSION} && ./configure && make && make install
+# Source the bash_profile in linux with `. ~/.bash_profile`
+RUN echo 'PATH="$HOME/bin/python3:$PATH"; export PATH' >> ~/.bash_profile && . ~/.bash_profile
+# Fixes https://trello.com/c/K6jmmjvo/29-conflicts-due-to-cached-pyc-files
+RUN echo 'export PYTHONDONTWRITEBYTECODE=1' >> ~/.bash_profile && . ~/.bash_profile
+
+RUN which python3; which pip3
+RUN python3 --version; pip3 --version
+RUN git clone --depth=50 https://github.com/ethereum/sharding.git ethereum/sharding
+RUN pip3 install setuptools==37
+
+COPY ./requirements.txt .
+COPY ./setup.py .
+COPY ./dev_requirements.txt .
+
+RUN USE_PYETHEREUM_DEVELOP=1 python3 setup.py develop
+RUN pip3 install -r dev_requirements.txt;
+
+WORKDIR /code

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,3 @@
 pytest>=2.9.0
-pytest-catchlog==1.2.2
 pytest-timeout==1.0.0
 pytest-cov>=2.5.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  sandbox:
+    # uses an image built from Dockerfile in current directory
+    build:
+      context: .
+    image: sharding:tag
+    volumes:
+      - .:/code
+    command: tail -f /dev/null

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -61,7 +61,7 @@ Where:
 
 -   `shard_id` is the shard ID of the shard;
 -   `expected_period_number` is the period number in which this collation expects to be included; this is calculated as `period_number = floor(block.number / PERIOD_LENGTH)`;
--   `period_start_prevhash` is the block hash of the block `PERIOD_LENGTH * expected_period_number - 1` (i.e., it is the hash of the last block before the expected period starts). Opcodes in the shard that refer to block data (e.g. NUMBER and DIFFICULTY) will refer to the data of this block, with the exception of COINBASE, which will refer to the shard coinbase;
+-   `period_start_prevhash` is the block hash of block `PERIOD_LENGTH * expected_period_number - 1` (i.e., it is the hash of the last block before the expected period starts). Opcodes in the shard that refer to block data (e.g. NUMBER and DIFFICULTY) will refer to the data of this block, with the exception of COINBASE, which will refer to the shard coinbase;
 -   `parent_collation_hash` is the hash of the parent collation;
 -   `tx_list_root` is the root hash of the trie holding the transactions included in this collation;
 -   `coinbase` is the address chosen by creator of Shard Header
@@ -258,10 +258,10 @@ Next, we have `CREATE_COLLATION`. For illustration, here is full pseudocode for 
 # Sort by descending order of gasprice
 txpool = sorted(copy(available_transactions), key=-tx.gasprice)
 collation = new Collation(...)
-remaining_gas = GASLIMIT - collation.gasused
 while len(txpool) > 0:
     # Remove txs that ask for too much gas
     i = 0
+    remaining_gas = GASLIMIT - collation.gasused
     while i < len(txpool):
         if txpool[i].startgas > remaining_gas:
             txpool.pop(i)

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -51,7 +51,7 @@ We first define a "collation header" as an RLP list with the following values:
         period_start_prevhash: bytes32,
         parent_collation_hash: bytes32,
         tx_list_root: bytes32,
-        coinbase: address,                  # address chosen by creator of Shard Header
+        coinbase: address,
         post_state_root: bytes32,
         receipts_root: bytes32,
         sig: bytes
@@ -61,9 +61,10 @@ Where:
 
 -   `shard_id` is the shard ID of the shard;
 -   `expected_period_number` is the period number in which this collation expects to be included; this is calculated as `period_number = floor(block.number / PERIOD_LENGTH)`;
--   `period_start_prevhash` is the block hash of the last block `PERIOD_LENGTH * expected_period_number - 1` (i.e., it is the hash of the last block before the expected period starts). Opcodes in the shard that refer to block data (e.g. NUMBER and DIFFICULTY) will refer to the data of this block, with the exception of COINBASE, which will refer to the shard coinbase;
+-   `period_start_prevhash` is the block hash of the block `PERIOD_LENGTH * expected_period_number - 1` (i.e., it is the hash of the last block before the expected period starts). Opcodes in the shard that refer to block data (e.g. NUMBER and DIFFICULTY) will refer to the data of this block, with the exception of COINBASE, which will refer to the shard coinbase;
 -   `parent_collation_hash` is the hash of the parent collation;
 -   `tx_list_root` is the root hash of the trie holding the transactions included in this collation;
+-   `coinbase` is the address chosen by creator of Shard Header
 -   `post_state_root` is the new state root of the shard after this collation;
 -   `receipts_root` is the root hash of the receipt trie; and
 -   `sig` is a signature.

--- a/readme.md
+++ b/readme.md
@@ -17,13 +17,13 @@ Please refer to [pyethereum - Developer-Notes](https://github.com/ethereum/pyeth
 
   2. [Setup Git Version Control](https://help.github.com/articles/fork-a-repo/#step-1-set-up-git)
 
-  2. [Clone](https://help.github.com/articles/fork-a-repo/#step-2-create-a-local-clone-of-your-fork) your fork of this repository. Replace `<YOUR_GITHUB_USERNAME>` below with your Github username.
+  3. [Clone](https://help.github.com/articles/fork-a-repo/#step-2-create-a-local-clone-of-your-fork) your fork of this repository. Replace `<YOUR_GITHUB_USERNAME>` below with your Github username.
     ```shell
     git clone https://github.com/<YOUR_GITHUB_USERNAME>/sharding/;
     cd sharding;
     ```
 
-  2. Show list of available Python versions.
+  4. Show list of available Python versions.
   [Install Homebrew](https://brew.sh/). Install PyEnv.
   Switch to latest version of Python (i.e. using [virtualenv](https://github.com/pypa/virtualenv) or [pyenv](https://github.com/pyenv/pyenv)).
   Verify the version of Python being used.
@@ -39,19 +39,19 @@ Please refer to [pyethereum - Developer-Notes](https://github.com/ethereum/pyeth
       * Latest Stable version of Python 3.6 (i.e. Python `3.6.4rc1`), which is recommended since Viper requires python3.6, and Pyethereum supports python3.6
       * Note: Python 3.7 Alpha has been release but may not be currently supported. What's new in Python 3.7 https://docs.python.org/3.7/whatsnew/3.7.html
 
-  3. Install dependencies specific to operating system
+  5. Install dependencies specific to operating system
 
     ```shell
     brew install pkg-config libffi autoconf automake libtool openssl
     ```
 
-  4. Show existing versions of Ethereum from PyPI and Viper that are installed - https://pip.pypa.io/en/stable/reference/pip_list/
+  6. Show existing versions of Ethereum from PyPI and Viper that are installed - https://pip.pypa.io/en/stable/reference/pip_list/
     ```shell
     pip install --upgrade pip;
     pip freeze | grep -i -E "ethereum|viper|setuptools"
     ```
 
-  5. Uninstall previously installed versions of Ethereum from PyPI and Viper. Uninstall PyTest Catchlog to avoid warnings when running Unit Tests. See #5 in Troubleshooting section.
+  7. Uninstall previously installed versions of Ethereum from PyPI and Viper. Uninstall PyTest Catchlog to avoid warnings when running Unit Tests. See #5 in Troubleshooting section.
     * WARNING: Do not install/reinstall Ethereum from PyPI manually. See #4 in Troubleshooting section below.
 
     ```shell
@@ -61,20 +61,20 @@ Please refer to [pyethereum - Developer-Notes](https://github.com/ethereum/pyeth
     python -m pip uninstall viper -y;
     ```
 
-  6. Install dependencies for Unit Testing, and Pyethereum and Viper from a specific branch and commit hash by setting the `USE_PYETHEREUM_DEVELOP` flag
+  8. Install dependencies for Unit Testing, and Pyethereum and Viper from a specific branch and commit hash by setting the `USE_PYETHEREUM_DEVELOP` flag
     ```
     python -m pip install setuptools==37;
     USE_PYETHEREUM_DEVELOP=1 python setup.py develop;
     python -m pip install -r dev_requirements.txt;
     ```
 
-  7. Run Unit Tests
+  9. Run Unit Tests
 
     ```shell
     pytest sharding/tests/
     ```
 
-  8. Contributing
+  10. Contributing
 
     i) Configure an remote called Upstream. Show remote configurations (your Fork of the Upstream repository is called Origin)
   
@@ -193,13 +193,3 @@ Please refer to [pyethereum - Developer-Notes](https://github.com/ethereum/pyeth
    Location: /Users/Ls/.pyenv/versions/3.6.4rc1/lib/python3.6/site-packages/ethereum-2.1.0-py3.6.egg
    Requires: py-ecc, scrypt, pyethash, future, pbkdf2, repoze.lru, pysha3, coincurve, pycryptodome, PyYAML, rlp
    ```
-
-5. Remove warning when running Unit Tests
-
-  * Problem: Warning appears when running Unit Tests: pytest-catchlog plugin has been merged into the core, please remove it from your requirements. Docs: http://doc.pytest.org/en/latest/warnings.html
-
-  * Solution: Uninstall the dependency. Removed from dev_requirements.txt
-
-    ```shell
-    python -m pip uninstall pytest-catchlog -y
-    ```

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,66 @@ See the "docs" directory for documentation and EIPs, and the "sharding" director
 
 Please refer to [pyethereum - Developer-Notes](https://github.com/ethereum/pyethereum/wiki/Developer-Notes)
 
+##### macOS using Docker
+
+  * About: Use Docker to create a Virtual Machine (VM) that builds and runs a Docker Container
+  according to the configuration in docker-compose.yml and Dockerfile. Any changes to Python scripts
+  are synchronised with a copy of the file in the code/ directory on the VM.
+
+  1. Install and Run Docker
+
+    * macOS - [Docker for Mac Community Edition (CE)](https://docs.docker.com/docker-for-mac/install/)
+
+      * Re-open from command line
+
+        ```shell
+        open /Applications/Docker.app/
+        ```
+
+    * Windows 10 - [Docker for Windows Community Edition (CE)](https://docs.docker.com/docker-for-windows/install/)
+
+  2. Run Docker Container
+
+    ```shell
+    docker-compose up --force-recreate --build -d
+    ```
+
+  3. Get the CONTAINER_ID
+
+    ```shell
+    docker ps -l
+    ```
+
+  4. Create Bash Terminal tab. Run interactive Docker shell
+
+    ```shell
+    docker exec -it <CONTAINER_ID> bash
+    ```
+
+  5. Remove all PyCached folders and files from within the Docker Container
+
+    ```shell
+    find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
+    ```
+
+  6. Run Unit Tests in Docker Container
+
+    ```shell
+    pytest sharding/tests/
+    ```
+
+  7. Show Docker Containers and their Networks
+
+    ```
+    docker network ps
+    ```
+
+  8. Stop and Remove Docker Containers, Networks, Images, and Volumes
+
+    ```
+    docker-compose down
+    ```
+
 ##### macOS
 
   1. [Fork](https://help.github.com/articles/fork-a-repo/#fork-an-example-repository) this Sharding Github repository

--- a/readme.md
+++ b/readme.md
@@ -51,11 +51,12 @@ Please refer to [pyethereum - Developer-Notes](https://github.com/ethereum/pyeth
     pip freeze | grep -i -E "ethereum|viper|setuptools"
     ```
 
-  5. Uninstall previously installed versions of Ethereum from PyPI and Viper.
+  5. Uninstall previously installed versions of Ethereum from PyPI and Viper. Uninstall PyTest Catchlog to avoid warnings when running Unit Tests. See #5 in Troubleshooting section.
     * WARNING: Do not install/reinstall Ethereum from PyPI manually. See #4 in Troubleshooting section below.
 
     ```shell
     python -m pip uninstall setuptools -y;
+    python -m pip uninstall pytest-catchlog -y
     python -m pip uninstall ethereum -y;
     python -m pip uninstall viper -y;
     ```
@@ -192,3 +193,13 @@ Please refer to [pyethereum - Developer-Notes](https://github.com/ethereum/pyeth
    Location: /Users/Ls/.pyenv/versions/3.6.4rc1/lib/python3.6/site-packages/ethereum-2.1.0-py3.6.egg
    Requires: py-ecc, scrypt, pyethash, future, pbkdf2, repoze.lru, pysha3, coincurve, pycryptodome, PyYAML, rlp
    ```
+
+5. Remove warning when running Unit Tests
+
+  * Problem: Warning appears when running Unit Tests: pytest-catchlog plugin has been merged into the core, please remove it from your requirements. Docs: http://doc.pytest.org/en/latest/warnings.html
+
+  * Solution: Uninstall the dependency. Removed from dev_requirements.txt
+
+    ```shell
+    python -m pip uninstall pytest-catchlog -y
+    ```

--- a/readme.md
+++ b/readme.md
@@ -13,11 +13,17 @@ Please refer to [pyethereum - Developer-Notes](https://github.com/ethereum/pyeth
 
 ##### macOS
 
-  1. Switch to supported version of Python (i.e. using [virtualenv](https://github.com/pypa/virtualenv) or [pyenv](https://github.com/pyenv/pyenv))
+  1. Show list of available Python versions. Switch to latest version of Python (i.e. using [virtualenv](https://github.com/pypa/virtualenv) or [pyenv](https://github.com/pyenv/pyenv)). Verify the version of Python being used.
 
     ```shell
-    pyenv install 3.5.0; pyenv global 3.5.0; pyenv versions;
+    pyenv install --list;
+    pyenv install 3.6.4rc1; pyenv global 3.6.4rc1;
+    pyenv versions; python --version
     ```
+
+    * Note: Supports the following versions of Python
+      * Latest Stable version of Python 3.6 (i.e. Python `3.6.4rc1`), which is recommended since Viper requires python3.6, and Pyethereum supports python3.6
+      * Note: Python 3.7 Alpha has been release but may not be currently supported. What's new in Python 3.7 https://docs.python.org/3.7/whatsnew/3.7.html
 
   2. Install dependencies specific to operating system
 
@@ -49,7 +55,7 @@ pip install -r dev_requirements.txt
 
 ##### macOS
 
-* SSL dependency error on macOS
+* OpenSSL dependency error on macOS
 
   * Problem: Error occurs when running `USE_PYETHEREUM_DEVELOP=1 python setup.py develop`
 
@@ -61,10 +67,38 @@ pip install -r dev_requirements.txt
     error: Setup script exited with error: command 'clang' failed with exit status 1
     ```
 
-  * Solution: Set SSL flags to valid directories
+  * Solution: Set SSL flags to valid directories. Use `which openssl` to verify where the OpenSSL binary executable is installed. If it is installed in `/usr/local/opt/openssl/bin` then OpenSSL is installed in `/usr/local/opt/openssl/`. Check that `/usr/local/opt/openssl/` contains the `lib` and `include` subdirectories with `ls -lha /usr/local/opt/openssl/`
 
     ```
     brew update; brew upgrade openssl; which openssl;
     export LDFLAGS="-L/usr/local/opt/openssl/lib";
     export CPPFLAGS="-I/usr/local/opt/openssl/include"
+    ```
+
+* OpenSSL symlinks broken
+
+  * Problem: Error occurred after first switching to a different Python version (i.e. 3.6.4rc1), installing dependencies with `python setup.py install`, and then trying to run Unit Tests with `pytest sharding/tests/`
+
+    ```
+    E   OSError: dlopen(/Users/Ls/.pyenv/versions/3.6.4rc1/lib/python3.6/site-packages/_scrypt.cpython-36m-darwin.so, 6): Library not loaded: @rpath/libcrypto.1.0.0.dylib
+    E     Referenced from: /Users/Ls/.pyenv/versions/3.6.4rc1/lib/python3.6/site-packages/_scrypt.cpython-36m-darwin.so
+    E     Reason: image not found
+    ```
+
+  * Solution: Run the following commands to fix symlinks. Reference: https://github.com/tihmstar/futurerestore/issues/25. Use `which openssl` to verify where the OpenSSL binary executable is installed to determine the OpenSSL root directory (i.e. /usr/local/opt/openssl/).
+
+    ```
+    ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/
+    ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/
+    ```
+
+* Latest Ethereum PyPI dependency not supported by Viper on macOS
+
+  * Problem: Error occurs when trying to install dependencies with `python setup.py install` such as `error: ethereum 2.3.0 is installed but ethereum==2.1.0 is required by {'viper'}` complaining that the version installed of [Ethereum from Python Package Index (PyPI)](https://pypi.python.org/pypi/ethereum/2.3.0) is not supported by Viper after upgrading to the latest version Python (i.e. Python 3.6 or 3.7)
+
+  * Solution: Uninstall old version and reinstall new version before running `python setup.py install` again
+
+    ```
+    python -m pip uninstall ethereum==2.3.0;
+    python -m pip install ethereum==2.1.0
     ```

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,22 @@ See the "docs" directory for documentation and EIPs, and the "sharding" director
 
 ## Installation
 ### Environment
+
 Please refer to [pyethereum - Developer-Notes](https://github.com/ethereum/pyethereum/wiki/Developer-Notes)
+
+##### macOS
+
+  1. Switch to supported version of Python (i.e. using [virtualenv](https://github.com/pypa/virtualenv) or [pyenv](https://github.com/pyenv/pyenv))
+
+    ```shell
+    pyenv install 3.5.0; pyenv global 3.5.0; pyenv versions;
+    ```
+
+  2. Install dependencies specific to operating system
+
+    ```shell
+    brew install pkg-config libffi autoconf automake libtool openssl
+    ```
 
 ### Install
 ```shell
@@ -26,5 +41,30 @@ USE_PYETHEREUM_DEVELOP=1 python setup.py develop
 
 ### Install development tool
 ```shell
+pip install --upgrade pip;
 pip install -r dev_requirements.txt
 ```
+
+### Troubleshooting
+
+##### macOS
+
+* SSL dependency error on macOS
+
+  * Problem: Error occurs when running `USE_PYETHEREUM_DEVELOP=1 python setup.py develop`
+
+    ```
+    scrypt-1.2.0/libcperciva/crypto/crypto_aes.c:6:10: fatal error: 'openssl/aes.h' file not found
+    #include <openssl/aes.h>
+             ^~~~~~~~~~~~~~~
+    1 error generated.
+    error: Setup script exited with error: command 'clang' failed with exit status 1
+    ```
+
+  * Solution: Set SSL flags to valid directories
+
+    ```
+    brew update; brew upgrade openssl; which openssl;
+    export LDFLAGS="-L/usr/local/opt/openssl/lib";
+    export CPPFLAGS="-I/usr/local/opt/openssl/include"
+    ```

--- a/readme.md
+++ b/readme.md
@@ -13,9 +13,23 @@ Please refer to [pyethereum - Developer-Notes](https://github.com/ethereum/pyeth
 
 ##### macOS
 
-  1. Show list of available Python versions. Switch to latest version of Python (i.e. using [virtualenv](https://github.com/pypa/virtualenv) or [pyenv](https://github.com/pyenv/pyenv)). Verify the version of Python being used.
+  1. [Fork](https://help.github.com/articles/fork-a-repo/#fork-an-example-repository) this Sharding Github repository
+
+  2. [Setup Git Version Control](https://help.github.com/articles/fork-a-repo/#step-1-set-up-git)
+
+  2. [Clone](https://help.github.com/articles/fork-a-repo/#step-2-create-a-local-clone-of-your-fork) your fork of this repository. Replace `<YOUR_GITHUB_USERNAME>` below with your Github username.
+    ```shell
+    git clone https://github.com/<YOUR_GITHUB_USERNAME>/sharding/;
+    cd sharding;
+    ```
+
+  2. Show list of available Python versions.
+  [Install Homebrew](https://brew.sh/). Install PyEnv.
+  Switch to latest version of Python (i.e. using [virtualenv](https://github.com/pypa/virtualenv) or [pyenv](https://github.com/pyenv/pyenv)).
+  Verify the version of Python being used.
 
     ```shell
+    brew update; brew install pyenv;
     pyenv install --list;
     pyenv install 3.6.4rc1; pyenv global 3.6.4rc1;
     pyenv versions; python --version
@@ -25,37 +39,74 @@ Please refer to [pyethereum - Developer-Notes](https://github.com/ethereum/pyeth
       * Latest Stable version of Python 3.6 (i.e. Python `3.6.4rc1`), which is recommended since Viper requires python3.6, and Pyethereum supports python3.6
       * Note: Python 3.7 Alpha has been release but may not be currently supported. What's new in Python 3.7 https://docs.python.org/3.7/whatsnew/3.7.html
 
-  2. Install dependencies specific to operating system
+  3. Install dependencies specific to operating system
 
     ```shell
     brew install pkg-config libffi autoconf automake libtool openssl
     ```
 
-### Install
-```shell
-git clone https://github.com/ethereum/sharding/
-cd sharding
-python setup.py install
-```
- 
-### Install with specific pyethereum branch and commit hash
-1. Update `setup.py`
-2. Set flag
-```shell
-USE_PYETHEREUM_DEVELOP=1 python setup.py develop
-```
+  4. Show existing versions of Ethereum from PyPI and Viper that are installed - https://pip.pypa.io/en/stable/reference/pip_list/
+    ```shell
+    pip install --upgrade pip;
+    pip freeze | grep -i -E "ethereum|viper|setuptools"
+    ```
 
-### Install development tool
-```shell
-pip install --upgrade pip;
-pip install -r dev_requirements.txt
-```
+  5. Uninstall previously installed versions of Ethereum from PyPI and Viper.
+    * WARNING: Do not install/reinstall Ethereum from PyPI manually. See #4 in Troubleshooting section below.
+
+    ```shell
+    python -m pip uninstall setuptools -y;
+    python -m pip uninstall ethereum -y;
+    python -m pip uninstall viper -y;
+    ```
+
+  6. Install dependencies for Unit Testing, and Pyethereum and Viper from a specific branch and commit hash by setting the `USE_PYETHEREUM_DEVELOP` flag
+    ```
+    python -m pip install setuptools==37;
+    USE_PYETHEREUM_DEVELOP=1 python setup.py develop;
+    python -m pip install -r dev_requirements.txt;
+    ```
+
+  7. Run Unit Tests
+
+    ```shell
+    pytest sharding/tests/
+    ```
+
+  8. Contributing
+
+    i) Configure an remote called Upstream. Show remote configurations (your Fork of the Upstream repository is called Origin)
+  
+      ```
+      git remote add upstream https://github.com/ethereum/sharding;
+      git remote -v;
+      ```
+
+    ii) Stay up-to-date with the develop branch of this Upstream repository https://github.com/ethereum/sharding by regularly pulling its latest changes to your local machine that has a clone of your fork using a [fetch and rebase](https://stackoverflow.com/a/44982185/3208553).
+
+      ```
+      git pull --rebase upstream develop
+      ```
+
+    iii) Create and check out a branch (feature `feat/<DESCRIPTION>`, fix `fix/<DESCRIPTION>`, docs `docs/<DESCRIPTION>`, or tests `tests/<DESCRIPTION>`) using this [Udemy Git Commit Style Guide](http://udacity.github.io/git-styleguide/)
+
+      ```
+      git checkout -b feat/my-feature-name;
+      ```
+
+    iv) Save changes and provide a meaningful commit message using using this [Udemy Git Commit Style Guide](http://udacity.github.io/git-styleguide/) and push the changes to your remote Fork
+
+      ```
+      git add . && git commit -m "feat: Add my feature" && git push origin feat/my-feature-name;
+      ```
+
+    v) Create a Pull Request from the remote branch "feat/my-feature-name" in your Fork (that you just pushed) to the "develop" branch in the Upstream repository
 
 ### Troubleshooting
 
 ##### macOS
 
-* OpenSSL dependency error on macOS
+1. OpenSSL dependency error on macOS
 
   * Problem: Error occurs when running `USE_PYETHEREUM_DEVELOP=1 python setup.py develop`
 
@@ -75,7 +126,7 @@ pip install -r dev_requirements.txt
     export CPPFLAGS="-I/usr/local/opt/openssl/include"
     ```
 
-* OpenSSL symlinks broken
+2. OpenSSL symlinks broken
 
   * Problem: Error occurred after first switching to a different Python version (i.e. 3.6.4rc1), installing dependencies with `python setup.py install`, and then trying to run Unit Tests with `pytest sharding/tests/`
 
@@ -92,7 +143,7 @@ pip install -r dev_requirements.txt
     ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/
     ```
 
-* Latest Ethereum PyPI dependency not supported by Viper on macOS
+3. Latest Ethereum PyPI dependency not supported by Viper on macOS
 
   * Problem: Error occurs when trying to install dependencies with `python setup.py install` such as `error: ethereum 2.3.0 is installed but ethereum==2.1.0 is required by {'viper'}` complaining that the version installed of [Ethereum from Python Package Index (PyPI)](https://pypi.python.org/pypi/ethereum/2.3.0) is not supported by Viper after upgrading to the latest version Python (i.e. Python 3.6 or 3.7)
 
@@ -102,3 +153,42 @@ pip install -r dev_requirements.txt
     python -m pip uninstall ethereum==2.3.0;
     python -m pip install ethereum==2.1.0
     ```
+
+4. Unit Test not passing due to Ethereum PyPI dependency failing
+
+ * Problem: Unit Test not passing due to error `E  KeyError: b'GENESIS_NUMBER'` in test file `sharding/tests/test_main_chain.py`
+   * References:
+     * https://github.com/ethereum/sharding/pull/51#issuecomment-355720781
+     * https://github.com/ethereum/sharding/pull/53
+
+* Solution: Do not install/reinstall Ethereum from Python Package Index (PyPI) or Viper manually (i.e. do not install with `python -m pip install ethereum==2.1.0`), as doing so does not install the dependency correctly. Instead install them using `USE_PYETHEREUM_DEVELOP=1 python setup.py develop`
+
+ * Example: If you incorrectly try to install Ethereum from PyPI manually with `python -m pip install ethereum==2.1.0`, then when you run `pip show ethereum` it shows the following:
+
+   ```shell
+   $ pip show ethereum
+   Name: ethereum
+   Version: 2.1.0
+   Summary: Next generation cryptocurrency network
+   Home-page: https://github.com/ethereum/pyethereum/
+   Author: UNKNOWN
+   Author-email: UNKNOWN
+   License: UNKNOWN
+   Location: /Users/Ls/.pyenv/versions/3.6.4rc1/lib/python3.6/site-packages
+   Requires: scrypt, pyethash, py-ecc, coincurve, PyYAML, rlp, pbkdf2, pycryptodome, repoze.lru, pysha3
+   ```
+
+ * Whereas when you correctly install Ethereum from PyPI using `USE_PYETHEREUM_DEVELOP=1 python setup.py develop` then when you run `pip show ethereum` you will notice that the value for its Location is provided, hence the reason why this approach works.
+
+   ```shell
+   $ pip show ethereum
+   Name: ethereum
+   Version: 2.1.0
+   Summary: Next generation cryptocurrency network
+   Home-page: https://github.com/ethereum/pyethereum/
+   Author: UNKNOWN
+   Author-email: UNKNOWN
+   License: UNKNOWN
+   Location: /Users/Ls/.pyenv/versions/3.6.4rc1/lib/python3.6/site-packages/ethereum-2.1.0-py3.6.egg
+   Requires: py-ecc, scrypt, pyethash, future, pbkdf2, repoze.lru, pysha3, coincurve, pycryptodome, PyYAML, rlp
+   ```


### PR DESCRIPTION
* Where it explains process of assigning a Validator to a specific Shard. Added clarity to show how a Validator becomes a Collator, and that they create Collations on Shards (not Blocks as they are referred to on the Main Chain)
* Add clarity to argument name of `addHeader`
* Add explanation of how `coinbase` is created
* Add clarity that `period_start_prevhash` is the block hash of the "last block"
* Minor grammar tweak (i.e. `sent not` changed to `not sent`)
* Clarity in pseudocode to show where it is referring to `remaining_gas`
* Add example Setup steps on macOS
* Add Troubleshooting section showing how to overcome common macOS error caused by SSL dependency
  