### PR TITLE
Fixed CI +  bug of test_get_eligible_proposer()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ cache: pip
 before_install:
   - sudo apt-get update
 install:
-  - pip install setuptools --upgrade
+  - pip install setuptools==37
   - USE_PYETHEREUM_DEVELOP=1 python setup.py develop
   - pip install -r dev_requirements.txt
 script:
   - pytest sharding/tests/
+group: deprecated-2017Q4

--- a/sharding/tests/test_validator_manager.py
+++ b/sharding/tests/test_validator_manager.py
@@ -319,7 +319,7 @@ def test_get_eligible_proposer():
     assert 0 == x.deposit(k0_valcode_addr, return_addr, value=DEPOSIT_SIZE, sender=t.k0)
     c.mine(4)
     period = c.chain.head.number // sharding_config['PERIOD_LENGTH'] + sharding_config['LOOKAHEAD_PERIODS']
-    x.get_eligible_proposer(1, period, is_constant=True) == hex(utils.big_endian_to_int(k0_valcode_addr))
+    assert x.get_eligible_proposer(1, period, is_constant=True) == hex(utils.big_endian_to_int(k0_valcode_addr))
 
     # case 3. if the num_validators == 0
     assert x.withdraw(0, sign(WITHDRAW_HASH, t.k0))


### PR DESCRIPTION
#### 1. Fixed CI
The reason why CI was broken earlier is that the setup.py of `pyethereum` commit doesn't compatible with the latest `setuptools`. So, sadly, this patch just set `pip install setuptools==37`.
#### 2. Fixed bug of `test_get_eligible_proposer()`
Added the missing `assert`.