### PR TITLE
Refactor and speed up tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,11 +2,11 @@ bumpversion>=0.5.3,<1
 flake8==3.5.0
 mypy==0.600
 hypothesis==3.44.26
+pytest==3.6.0
 pytest-asyncio==0.8.0
 pytest-cov==2.5.1
-pytest-logging>=2015.11.4
-pytest-xdist==1.18.1
-pytest==3.1.2
-tox==2.7.0
+pytest-logging>=0.3.0
+pytest-xdist==1.22.2
+tox==3.0.0
 eth-tester[py-evm]==0.1.0-beta.26
 git+git://github.com/ethereum/vyper.git@08ba8ed7c3c84d44edda85ff28c96bd1e2d867fe

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@ from eth_tester import (
 from eth_tester.backends.pyevm.main import (
     get_default_account_keys,
 )
-
 from sharding.handler.smc_handler import (
     SMCHandler,
 )
@@ -30,16 +29,21 @@ from sharding.contracts.utils.smc_utils import (
 from sharding.handler.utils.web3_utils import (
     get_code,
 )
-from tests.handler.utils.deploy import (
-    deploy_smc_contract,
-)
 from tests.handler.utils.config import (
     get_sharding_testing_config,
 )
+from tests.handler.utils.deploy import (
+    deploy_smc_contract,
+)
+
+
+@pytest.fixture(scope="session")
+def smc_testing_config():
+    return get_sharding_testing_config()
 
 
 @pytest.fixture
-def smc_handler():
+def smc_handler(smc_testing_config):
     eth_tester = EthereumTester(
         backend=PyEVMBackend(),
         auto_mine_transactions=False,
@@ -53,7 +57,7 @@ def smc_handler():
     # deploy smc contract
     smc_addr = deploy_smc_contract(
         w3,
-        get_sharding_testing_config()['GAS_PRICE'],
+        smc_testing_config['GAS_PRICE'],
         default_privkey,
     )
     assert get_code(w3, smc_addr) != b''
@@ -66,7 +70,7 @@ def smc_handler():
     smc_handler = SMCHandlerClass(
         to_checksum_address(smc_addr),
         default_privkey=default_privkey,
-        config=get_sharding_testing_config(),
+        config=smc_testing_config,
     )
 
     return smc_handler

--- a/tests/contract/test_add_header.py
+++ b/tests/contract/test_add_header.py
@@ -1,9 +1,7 @@
 from sharding.handler.utils.web3_utils import (
     mine,
 )
-from tests.handler.fixtures import (  # noqa: F401
-    smc_handler,
-)
+
 from tests.contract.utils.common_utils import (
     batch_register,
     fast_forward,

--- a/tests/contract/test_log_emission.py
+++ b/tests/contract/test_log_emission.py
@@ -7,9 +7,7 @@ from sharding.handler.shard_tracker import (  # noqa: F401
 from sharding.handler.utils.web3_utils import (
     mine,
 )
-from tests.handler.fixtures import (  # noqa: F401
-    smc_handler,
-)
+
 from tests.contract.utils.common_utils import (
     fast_forward,
 )
@@ -19,17 +17,13 @@ from tests.contract.utils.notary_account import (
 from tests.contract.utils.sample_helper import (
     sampling,
 )
-from tests.handler.utils.config import (
-    get_sharding_testing_config,
-)
 
 
 def test_log_emission(smc_handler):  # noqa: F811
     w3 = smc_handler.web3
-    config = get_sharding_testing_config()
-    log_handler = LogHandler(w3=w3, period_length=config['PERIOD_LENGTH'])
+    log_handler = LogHandler(w3=w3, period_length=smc_handler.config['PERIOD_LENGTH'])
     shard_tracker = ShardTracker(
-        config=config,
+        config=smc_handler.config,
         shard_id=0,
         log_handler=log_handler,
         smc_handler_address=smc_handler.address,

--- a/tests/contract/test_notary_sample.py
+++ b/tests/contract/test_notary_sample.py
@@ -1,9 +1,7 @@
 from sharding.handler.utils.web3_utils import (
     mine,
 )
-from tests.handler.fixtures import (  # noqa: F401
-    smc_handler,
-)
+
 from tests.contract.utils.common_utils import (
     update_notary_sample_size,
     batch_register,

--- a/tests/contract/test_registry_management.py
+++ b/tests/contract/test_registry_management.py
@@ -1,9 +1,7 @@
 from sharding.handler.utils.web3_utils import (
     mine,
 )
-from tests.handler.fixtures import (  # noqa: F401
-    smc_handler,
-)
+
 from tests.contract.utils.common_utils import (
     batch_register,
     fast_forward,
@@ -120,7 +118,7 @@ def test_normal_deregister(smc_handler):  # noqa: F811
     assert notary_pool_length == 1
 
     # Fast foward
-    mine(w3, 100 - w3.eth.blockNumber)
+    mine(w3, 20 - w3.eth.blockNumber)
 
     # Deregister notary 0
     smc_handler.deregister_notary(private_key=notary_0.private_key)
@@ -150,7 +148,7 @@ def test_deregister_then_register(smc_handler):  # noqa: F811
     assert notary_pool_length == 1
 
     # Fast foward
-    mine(w3, 100 - w3.eth.blockNumber)
+    mine(w3, 20 - w3.eth.blockNumber)
 
     # Deregister notary 0
     smc_handler.deregister_notary(private_key=notary_0.private_key)
@@ -189,7 +187,7 @@ def test_normal_release_notary(smc_handler):  # noqa: F811
     assert notary_pool_length == 1
 
     # Fast foward
-    mine(w3, 50 - w3.eth.blockNumber)
+    mine(w3, 20 - w3.eth.blockNumber)
 
     # Deregister notary 0
     smc_handler.deregister_notary(private_key=notary_0.private_key)
@@ -221,7 +219,7 @@ def test_instant_release_notary(smc_handler):  # noqa: F811
     assert notary_pool_length == 1
 
     # Fast foward
-    mine(w3, 50 - w3.eth.blockNumber)
+    mine(w3, 20 - w3.eth.blockNumber)
 
     # Deregister notary 0
     smc_handler.deregister_notary(private_key=notary_0.private_key)
@@ -262,7 +260,7 @@ def test_deregister_and_new_notary_register(smc_handler):  # noqa: F811
     assert empty_slots_stack_top == 0
 
     # Fast foward
-    mine(w3, 50 - w3.eth.blockNumber)
+    mine(w3, 20 - w3.eth.blockNumber)
 
     # Deregister notary 2
     smc_handler.deregister_notary(private_key=notary_2.private_key)

--- a/tests/contract/test_registry_management.py
+++ b/tests/contract/test_registry_management.py
@@ -118,7 +118,7 @@ def test_normal_deregister(smc_handler):  # noqa: F811
     assert notary_pool_length == 1
 
     # Fast foward
-    mine(w3, 20 - w3.eth.blockNumber)
+    fast_forward(smc_handler, 1)
 
     # Deregister notary 0
     smc_handler.deregister_notary(private_key=notary_0.private_key)
@@ -148,7 +148,7 @@ def test_deregister_then_register(smc_handler):  # noqa: F811
     assert notary_pool_length == 1
 
     # Fast foward
-    mine(w3, 20 - w3.eth.blockNumber)
+    fast_forward(smc_handler, 1)
 
     # Deregister notary 0
     smc_handler.deregister_notary(private_key=notary_0.private_key)
@@ -187,7 +187,7 @@ def test_normal_release_notary(smc_handler):  # noqa: F811
     assert notary_pool_length == 1
 
     # Fast foward
-    mine(w3, 20 - w3.eth.blockNumber)
+    fast_forward(smc_handler, 1)
 
     # Deregister notary 0
     smc_handler.deregister_notary(private_key=notary_0.private_key)
@@ -219,7 +219,7 @@ def test_instant_release_notary(smc_handler):  # noqa: F811
     assert notary_pool_length == 1
 
     # Fast foward
-    mine(w3, 20 - w3.eth.blockNumber)
+    fast_forward(smc_handler, 1)
 
     # Deregister notary 0
     smc_handler.deregister_notary(private_key=notary_0.private_key)
@@ -260,7 +260,7 @@ def test_deregister_and_new_notary_register(smc_handler):  # noqa: F811
     assert empty_slots_stack_top == 0
 
     # Fast foward
-    mine(w3, 20 - w3.eth.blockNumber)
+    fast_forward(smc_handler, 1)
 
     # Deregister notary 2
     smc_handler.deregister_notary(private_key=notary_2.private_key)

--- a/tests/contract/test_submit_vote.py
+++ b/tests/contract/test_submit_vote.py
@@ -3,9 +3,7 @@ import pytest
 from sharding.handler.utils.web3_utils import (
     mine,
 )
-from tests.handler.fixtures import (  # noqa: F401
-    smc_handler,
-)
+
 from tests.contract.utils.common_utils import (
     batch_register,
     fast_forward,

--- a/tests/handler/test_log_handler.py
+++ b/tests/handler/test_log_handler.py
@@ -35,9 +35,6 @@ from sharding.handler.utils.web3_utils import (
     revert_to_snapshot,
 )
 
-from tests.handler.utils.config import (
-    get_sharding_testing_config,
-)
 
 code = """
 Test: __log__({amount1: num})
@@ -75,8 +72,8 @@ def contract():
     return w3.eth.contract(contract_address, abi=abi, bytecode=bytecode)
 
 
-def test_get_logs_without_forks(contract):
-    period_length = get_sharding_testing_config()['PERIOD_LENGTH']
+def test_get_logs_without_forks(contract, smc_testing_config):
+    period_length = smc_testing_config['PERIOD_LENGTH']
     w3 = contract.web3
     log_handler = LogHandler(w3, period_length=period_length)
     counter = itertools.count()
@@ -105,9 +102,9 @@ def test_get_logs_without_forks(contract):
     assert int(logs_block4_5[1]['data'], 16) == 3
 
 
-def test_get_logs_with_forks(contract):
+def test_get_logs_with_forks(contract, smc_testing_config):
     w3 = contract.web3
-    log_handler = LogHandler(w3, period_length=get_sharding_testing_config()['PERIOD_LENGTH'])
+    log_handler = LogHandler(w3, period_length=smc_testing_config['PERIOD_LENGTH'])
     counter = itertools.count()
     snapshot_id = take_snapshot(w3)
     current_block_number = w3.eth.blockNumber

--- a/tests/handler/test_shard_tracker.py
+++ b/tests/handler/test_shard_tracker.py
@@ -18,12 +18,6 @@ from sharding.handler.utils.web3_utils import (
     mine,
 )
 
-from tests.handler.fixtures import (  # noqa: F401
-    smc_handler,
-)
-from tests.handler.utils.config import (
-    get_sharding_testing_config,
-)
 from tests.contract.utils.common_utils import (
     batch_register,
     fast_forward,
@@ -157,9 +151,9 @@ def test_log_parser_with_wrong_log_content(raw_log, event_name):
         LogParser(event_name=event_name, log=raw_log)
 
 
-def test_status_checking_functions(smc_handler):  # noqa: F811
+def test_status_checking_functions(smc_handler, smc_testing_config):  # noqa: F811
     w3 = smc_handler.web3
-    config = get_sharding_testing_config()
+    config = smc_testing_config
     log_handler = LogHandler(w3=w3, period_length=config['PERIOD_LENGTH'])
     shard_tracker = ShardTracker(
         config=config,

--- a/tests/handler/utils/config.py
+++ b/tests/handler/utils/config.py
@@ -13,7 +13,7 @@ def get_sharding_testing_config():
         'PERIOD_LENGTH': 10,
         'COMMITTEE_SIZE': 6,
         'QUORUM_SIZE': 4,
-        'NOTARY_LOCKUP_LENGTH': 60,
+        'NOTARY_LOCKUP_LENGTH': 30,
     }
     return merge(
         get_sharding_config(),

--- a/tests/handler/utils/deploy.py
+++ b/tests/handler/utils/deploy.py
@@ -32,17 +32,17 @@ from tests.handler.utils.config import (
 )
 
 
-def constructor_arguments():
+def constructor_arguments(config):
     """Encode system parameters passed into SMC constructor
     """
     arguments = (
-        int_to_bytes32(get_sharding_testing_config()['SHARD_COUNT']) +
-        int_to_bytes32(get_sharding_testing_config()['PERIOD_LENGTH']) +
-        int_to_bytes32(get_sharding_testing_config()['LOOKAHEAD_PERIODS']) +
-        int_to_bytes32(get_sharding_testing_config()['COMMITTEE_SIZE']) +
-        int_to_bytes32(get_sharding_testing_config()['QUORUM_SIZE']) +
-        int_to_bytes32(get_sharding_testing_config()['NOTARY_DEPOSIT']) +
-        int_to_bytes32(get_sharding_testing_config()['NOTARY_LOCKUP_LENGTH'])
+        int_to_bytes32(config['SHARD_COUNT']) +
+        int_to_bytes32(config['PERIOD_LENGTH']) +
+        int_to_bytes32(config['LOOKAHEAD_PERIODS']) +
+        int_to_bytes32(config['COMMITTEE_SIZE']) +
+        int_to_bytes32(config['QUORUM_SIZE']) +
+        int_to_bytes32(config['NOTARY_DEPOSIT']) +
+        int_to_bytes32(config['NOTARY_LOCKUP_LENGTH'])
     )
     return arguments
 
@@ -50,7 +50,7 @@ def constructor_arguments():
 def make_deploy_smc_tx(TransactionClass, gas_price):
     smc_json = get_smc_json()
     smc_bytecode = decode_hex(smc_json['bytecode'])
-    tx_data = smc_bytecode + constructor_arguments()
+    tx_data = smc_bytecode + constructor_arguments(get_sharding_testing_config())
     v = 27
     r = 1000000000000000000000000000000000000000000000000000000000000000000000000000
     s = 1000000000000000000000000000000000000000000000000000000000000000000000000000


### PR DESCRIPTION
### What was wrong?
Investigating #92

### How was it fixed?
1. Updated `pytest` to `3.6.0`
2. It seems `smc_handler` fixture is being used everywhere. Added `tests/conftest.py` for it.
3. Set testing `NOTARY_LOCKUP_LENGTH` from `60` to `30`.
4. Modified the `block_number` in `mine(block_number)` from `50` or `100` to `20`.

#### Benchmark
##### 1. previous code + `pytest==3.1.2`
```
===================================================== slowest 5 test durations ======================================================
40.59s call     tests/contract/test_registry_management.py::test_normal_release_notary
36.59s call     tests/handler/test_shard_tracker.py::test_status_checking_functions
31.91s call     tests/contract/test_log_emission.py::test_log_emission
5.12s call     tests/contract/test_submit_vote.py::test_normal_submit_vote
4.12s call     tests/contract/test_submit_vote.py::test_submit_vote_by_notary_sampled_multiple_times
==================================================== 56 passed in 168.27 seconds =====================================================
```

##### 2. previous code + `pytest==3.6.0`
```
===================================================== slowest 5 test durations ======================================================
35.01s call     tests/handler/test_shard_tracker.py::test_status_checking_functions
31.85s call     tests/contract/test_log_emission.py::test_log_emission
29.25s call     tests/contract/test_registry_management.py::test_normal_release_notary
2.64s call     tests/contract/test_notary_sample.py::test_get_sample_result
2.56s call     tests/contract/test_submit_vote.py::test_normal_submit_vote
==================================================== 56 passed in 134.44 seconds =====================================================
```

##### 3. new code + `pytest==3.6.0`
```
===================================================== slowest 5 test durations ======================================================
13.90s call     tests/handler/test_shard_tracker.py::test_status_checking_functions
12.63s call     tests/contract/test_registry_management.py::test_normal_release_notary
12.32s call     tests/contract/test_log_emission.py::test_log_emission
3.21s call     tests/contract/test_notary_sample.py::test_get_sample_result
2.62s call     tests/contract/test_submit_vote.py::test_normal_submit_vote
===================================================== 56 passed in 75.93 seconds =====================================================
```

#### Cute Animal Picture

![300356600_d22d497ba0_z](https://user-images.githubusercontent.com/9263930/40589094-1016616c-621a-11e8-9cc1-9ef3a86d867a.jpg)
