### PR TITLE
Include sharding manager JSON file in installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     setup_requires=['setuptools-markdown'],
     long_description_markdown_filename='README.md',
     include_package_data=True,
+    data_files=[('sharding', ['sharding/contracts/sharding_manager.json'])],
     zip_safe=False,
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
### What was wrong?

`sharding_manager.json` was not installed which led to errors when attempting to import the `SMCHandler`.

### How was it fixed?

Explicitly include the file.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/40974755-d7dde83c-68c8-11e8-99b2-81b3595e1b4b.jpg)

