### PR TITLE
Add SMC json file to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include README.md
 include requirements.txt
 include requirements-dev.txt
+
+include sharding/contracts/sharding_manager.json

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
     setup_requires=['setuptools-markdown'],
     long_description_markdown_filename='README.md',
     include_package_data=True,
-    data_files=[('sharding', ['sharding/contracts/sharding_manager.json'])],
     zip_safe=False,
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
### What was wrong?

`sharding_manager.json` has not been included in the package on PyPI.

### How was it fixed?

Add it to `MANIFEST` file.
