### PR TITLE
Add more commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,46 @@ $(contract_json): $(contract)
 # Commands
 help:
 	@echo "compile-smc - compile sharding manager contract"
+	@echo "clean - remove build and Python file artifacts"
+	@echo "clean-build - remove build artifacts"
+	@echo "clean-pyc - remove Python file artifacts"
+	@echo "lint - check style with flake8 and mypy"
+	@echo "test - run tests quickly with the default Python"
+	@echo "test-all - run tox"
+	@echo "release - package and upload a release"
+	@echo "dist - package"
 
 compile-smc: $(contract_json)
+
+clean: clean-build clean-pyc
+
+clean-build:
+	rm -fr build/
+	rm -fr dist/
+	rm -fr *.egg-info
+
+clean-pyc:
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+
+lint:
+	tox -elint3{5,6}
+
+test:
+	py.test --tb native tests
+
+test-all:
+	tox
+
+release: clean
+	CURRENT_SIGN_SETTING=$(git config commit.gpgSign)
+	git config commit.gpgSign true
+	bumpversion $(bump)
+	git push upstream && git push upstream --tags
+	python setup.py sdist bdist_wheel upload
+	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"
+
+sdist: clean
+	python setup.py sdist bdist_wheel
+	ls -l dist


### PR DESCRIPTION
### What was wrong?
Make the releasing easier.

### How was it fixed?
Copied from https://github.com/ethereum/py-evm/blob/master/Makefile
Added `release` command and also `test`, `lint`... commands.

#### Cute Animal Picture

![donkeys-in-love](https://user-images.githubusercontent.com/9263930/41147331-b1f006a6-6b38-11e8-9fc8-21b45ab5b13e.jpg)
